### PR TITLE
Create refs file if it doesn't already exist.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,12 +8,19 @@ var gulp = require('gulp'),
     sourcemaps = require('gulp-sourcemaps'),
     clean = require('gulp-clean'),
     config = require('./gulpfile.config'),
-    tsProject = tsc.createProject('tsconfig.json');
+    tsProject = tsc.createProject('tsconfig.json'),
+    fs = require('fs');
 
 /**
  * Generates the app.d.ts references file dynamically from all application *.ts files.
  */
 gulp.task('gen-ts-refs', function () {
+    fs.writeFile(config.appTypeScriptReferences, '//{\n//}', function(err) {
+        if (err) {
+            return console.log(err);
+        }
+        console.log("Created: " + config.appTypeScriptReferences);
+    });
     var target = gulp.src(config.appTypeScriptReferences);
     var sources = gulp.src([config.allTypeScript], {read: false});
     return target.pipe(inject(sources, {
@@ -65,7 +72,7 @@ gulp.task('clean-ts', function () {
 });
 
 gulp.task('watch', function() {
-    gulp.watch([config.allTypeScript], ['ts-lint', 'compile-ts', 'gen-ts-refs']);
+    gulp.watch([config.allTypeScript], ['ts-lint', 'gen-ts-refs', 'compile-ts']);
 });
 
-gulp.task('default', ['ts-lint', 'compile-ts', 'gen-ts-refs', 'watch']);
+gulp.task('default', ['ts-lint', 'gen-ts-refs', 'compile-ts', 'watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,12 +15,9 @@ var gulp = require('gulp'),
  * Generates the app.d.ts references file dynamically from all application *.ts files.
  */
 gulp.task('gen-ts-refs', function () {
-    fs.writeFile(config.appTypeScriptReferences, '//{\n//}', function(err) {
-        if (err) {
-            return console.log(err);
-        }
-        console.log("Created: " + config.appTypeScriptReferences);
-    });
+    fs.writeFileSync(config.appTypeScriptReferences, '//{\n//}');
+    console.log("Saved: " + config.appTypeScriptReferences);
+
     var target = gulp.src(config.appTypeScriptReferences);
     var sources = gulp.src([config.allTypeScript], {read: false});
     return target.pipe(inject(sources, {


### PR DESCRIPTION
Thanks for this tutorial. I'd like to suggest a small addition to create the TS references file if it doesn't already exist after a clean checkout, so a JS IDE (like WebStorm) compiles the sources cleanly in the first pass.
