### PR TITLE
Fix path issue.

### DIFF
--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -38,7 +38,7 @@ var routes = function () {
                 }
 
                 //Load the JavaScript file ("controller") and pass the router to it
-                require('../' + fullName)(router);
+                require(fullName)(router);
                 //Associate the route with the router
                 app.use(baseRoute, router);
             }

--- a/src/server.js
+++ b/src/server.js
@@ -37,7 +37,7 @@ process.on('uncaughtException', function(err) {
 //*********************************************************
 //    Convention based route loading (saves a lot of code)
 //*********************************************************
-routes.load(app, './controllers');
+routes.load(app, __dirname + '/controllers');
 
 app.listen(port, function (err) {
     console.log('[%s] Listening on http://localhost:%d', app.settings.env, port);


### PR DESCRIPTION
Running `node server.js` was expecting `server.js` to be in the root of the project, not the `src` directory. With this patch you can now run the app via `node src/server.js`.
